### PR TITLE
Use esutils.ast.isProblematicIfStatement

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,11 +33,6 @@ var isSourceElement = esutils.ast.isSourceElement;
 
 var OBJECT_PROPERTY_KINDS = ["init", "get", "set"];
 
-// isProblematicIfStatement :: Node -> Boolean
-function isProblematicIfStatement(node) {
-  return node.type === "IfStatement" && (node.alternate == null || isProblematicIfStatement(node.alternate));
-}
-
 var ASSIGNMENT_OPERATORS = ["=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "|=", "^=", "&="];
 var BINARY_OPERATORS = ["==", "!=", "===", "!==", "<", "<=", ">", ">=", "<<", ">>", ">>>", "+", "-", "*", "/", "%", "|", "^", "&", "in", "instanceof"];
 var LOGICAL_OPERATORS = ["||", "&&"];
@@ -340,7 +335,8 @@ function errorsP(state) {
           errors.push(new E(node, "IfStatement `consequent` member must be a statement node"));
         if (node.alternate != null && !isStatement(node.alternate))
           errors.push(new E(node, "IfStatement `alternate` member must be a statement node or null"));
-        if (node.alternate != null && node.consequent != null && isProblematicIfStatement(node.consequent))
+        if (node.alternate != null && node.consequent != null && esutils.ast.isProblematicIfStatement(node))
+
           errors.push(new E(node, "IfStatement with null `alternate` must not be the `consequent` of an IfStatement with a non-null `alternate`"));
         if (node.test != null)
           [].push.apply(errors, recurse(node.test));

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/michaelficarra/esvalid",
   "dependencies": {
-    "esutils": "^1.1.0",
+    "esutils": "^1.1.4",
     "object-assign": "^0.3.1"
   },
   "devDependencies": {

--- a/test/unit.js
+++ b/test/unit.js
@@ -291,6 +291,7 @@ suite("unit", function(){
     validStmt({type: "IfStatement", test: EXPR, consequent: BLOCK, alternate: BLOCK});
     validStmt({type: "IfStatement", test: EXPR, consequent: STMT, alternate: BLOCK});
     validStmt({type: "IfStatement", test: EXPR, consequent: BLOCK, alternate: STMT});
+    validStmt({type: "IfStatement", test: EXPR, consequent: {type: "DoWhileStatement", test: EXPR, body: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
     invalidStmt({type: "IfStatement"});
     invalidStmt({type: "IfStatement", test: EXPR});
     invalidStmt({type: "IfStatement", test: STMT, consequent: STMT});
@@ -300,6 +301,11 @@ suite("unit", function(){
     invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "IfStatement", test: EXPR, consequent: STMT}, alternate: STMT});
     invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "IfStatement", test: EXPR, consequent: STMT, alternate: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
     invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "IfStatement", test: EXPR, consequent: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
+    invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "LabeledStatement", label: ID, body: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
+    invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "WhileStatement", test: EXPR, body: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
+    invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "WithStatement", object: EXPR, body: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
+    invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "ForStatement", init: EXPR, test: EXPR, update: EXPR, body: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
+    invalidStmt({type: "IfStatement", test: EXPR, consequent: {type: "ForInStatement", left: EXPR, right: EXPR, body: {type: "IfStatement", test: EXPR, consequent: STMT}}, alternate: STMT});
   });
 
   test("LabeledStatement", function() {


### PR DESCRIPTION
I've extracted `esmangle`'s `isProblematicIfStatement` routine to `esutils`.
It covers edge cases. For example,

``` js
{
    type: "IfStatement",
    test: EXPR,
    consequent: {
        type: "LabeledStatement",
        body: {type: "IfStatement", test: EXPR, consequent: STMT}
    },
    alternate: STMT
}
```

is also an invalid node.
